### PR TITLE
fix: ensure that the return value is provided after all executions

### DIFF
--- a/basic-delay/index.js
+++ b/basic-delay/index.js
@@ -12,10 +12,9 @@ const options = {};
 const breaker = new CircuitBreaker(delay, options);
 
 function go() {
-  breaker.fire(100)
-  .then()
-  .catch(error => console.error(error));
-  return breaker.stats;
+  return breaker.fire(100)
+    .then(_ => breaker.stats)
+    .catch(error => console.error(error))
 }
 
 module.exports = {


### PR DESCRIPTION
This commit ensures that when returning the function stats, they have
fully resolved as async results.

Fixes: https://github.com/nodeshift-starters/opossum-playground/issues/10