### PR TITLE
src: fix failure-with-reset

### DIFF
--- a/debuglog/core/failure-with-reset/index.js
+++ b/debuglog/core/failure-with-reset/index.js
@@ -1,20 +1,24 @@
 const CircuitBreaker = require('opossum');
 
-const throwError = () => new Promise((_, reject) => {
-  reject('Something went wrong!');
+let count = 0;
+
+const throwErrorSometimes = () => new Promise((resolve, reject) => {
+  if (++count % 2) return reject('Something went wrong!');
+  resolve('It works!');
 });
 
-const breaker = new CircuitBreaker(throwError, { resetTimeout: 5000 });
+const breaker = new CircuitBreaker(throwErrorSometimes, { resetTimeout: 5000 });
 
 const fireOpossum = () => {
   breaker
   .fire(100)
-  .then((_) => {
+  .then((result) => {
     console.log(
       'fires',
       breaker.stats.fires,
       'successes',
-      breaker.stats.successes
+      breaker.stats.successes,
+      result
     );
   })
   .catch((error) => console.error(error));


### PR DESCRIPTION
As written, circuit will never enter the `closed` state because after waiting for the timeout to elapse, the circuit goes into `halfOpen` state. In that state, if the next invocation fails, the circuit immediately opens.

This change modifies the example so that the `throwError` function does not throw the second time it is called.